### PR TITLE
Trigger correct events

### DIFF
--- a/classes/converter.php
+++ b/classes/converter.php
@@ -199,7 +199,7 @@ class converter implements \core_files\converter_interface {
                 'id' => $conversion->get('id'),
                 'status' => $this->status
             ));
-        $event = \fileconverter_onlyoffice\event\poll_conversion_status::create($eventinfo);
+        $event = \fileconverter_onlyoffice\event\start_document_conversion::create($eventinfo);
         $event->trigger();
 
         return $this;


### PR DESCRIPTION
`start_document_conversion` was implemented but unused. Instead, a `poll_conversion_status` event was triggered on start.